### PR TITLE
Support for new numeric operators (gt, lt, gte, lte, ne) for table filtering

### DIFF
--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -1462,12 +1462,45 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                                 var query_part = query_parts[i].split(':');
                                 var field = query_part[0];
                                 var value = query_part[1];
+                                var operator = query_part[2];                                
 
                                 // if numeric check for exact match otherwise check for partial match
-                                if (!isNaN(value)) {
-                                    if (row[field] != value) {
-                                        result = false;
-                                    }
+                                if (!isNaN(value)) {                                    
+                                    // optional - select operator (e.g. gt, lt, gte, lte, ne), default is 'equals'
+                                    // the additional benefit of 'greater'/'less than' operators is that they can be used for specifying ranges of values
+                                    switch (operator) {
+                                        case 'gt':
+                                            if (!(row[field] > value)) {
+                                                result = false;
+                                            }
+                                            break;
+                                        case 'lt':
+                                            if (!(row[field] < value)) {
+                                                result = false;
+                                            }
+                                            break;
+                                        case 'gte':
+                                            if (!(row[field] >= value)) {
+                                                result = false;
+                                            }
+                                            break;
+                                        case 'lte':
+                                            if (!(row[field] <= value)) {
+                                                result = false;
+                                            }
+                                            break;
+                                        case 'ne':
+                                            if (!(row[field] != value)) {
+                                                result = false;
+                                            }
+                                            break;
+                                        default:
+                                            // the default operator is 'equals', which is the original behaviour before adding support for other operators
+                                            if (row[field] != value) {
+                                                result = false;
+                                            }
+                                    }          
+                                // if not numeric check for partial match                                                          
                                 } else {
                                     if (String(row[field]).toLowerCase().indexOf(value.toLowerCase()) == -1) {
                                         result = false;
@@ -1475,7 +1508,7 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                                 }
                             }
                             return result;
-
+                        // search all fields and check if any contains the searched value (filterKey)
                         } else {
                             return Object.keys(row).some((key) => {
                                 return String(row[key]).toLowerCase().indexOf(this.filterKey.toLowerCase()) > -1


### PR DESCRIPTION
This enhancement is for the system list table filtering, supplementing it with additional operators applicable to numeric fields. 

The additional operators are:
- Greater than (`gt`)
- Less than (`lt`)
- Greater than or equal (`gte`)
- Less than or equal (`lte`)
- Not equal (`ne`)
- Anything else defaults to equals (the original behaviour)

The format is backwards compatible and works in URLs as before:

- all previous query strings will work as before
- mixed default (equals) and new operator: `query:hp_output:5:gt,UFH:0` (output to be greater than 5, UFH quals to 0)

Other examples:

- `query:hp_output:5:gt,UFH:0,old_radiators:1,combined_cop:4:lt,combined_cop:3:gt`
- `query:hp_output:5:gt,UFH:0,old_radiators:1,combined_cop:4:lt,combined_cop:3:gt,combined_flowT_mean:35:lt`

You can also specify ranges, e.g.:

- `query:combined_flowT_mean:35:lt,combined_flowT_mean:33:gt`