### PR TITLE
Changed the text colour in the data coverage table to be more readable

### DIFF
--- a/www/Modules/system/system_view.php
+++ b/www/Modules/system/system_view.php
@@ -23,7 +23,6 @@ global $settings, $session, $path;
         padding: 5px;
         text-align: center;
         border: 1px solid #fff;
-        color: #fff;
         font-size: 14px;
     }
 </style>
@@ -99,31 +98,31 @@ global $settings, $session, $path;
                     </tr>
                     <tr>
                         <td>Elec</td>
-                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_elec) }">
+                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_elec), color: qualityColorText(month.quality_elec) }">
                         {{ month.quality_elec | toFixed(0) }}
                         </td>
                     </tr>
                     <tr>
                         <td>Heat</td>
-                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_heat) }">
+                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_heat), color: qualityColorText(month.quality_heat) }">
                             {{ month.quality_heat | toFixed(0) }}
                         </td>
                     </tr>
                     <tr>
                         <td>Flow</td>
-                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_flowT) }">
+                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_flowT), color: qualityColorText(month.quality_flowT) }">
                             {{ month.quality_flowT | toFixed(0) }}
                         </td>
                     </tr>
                     <tr>
                         <td>Return</td>
-                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_returnT) }">
+                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_returnT), color: qualityColorText(month.quality_returnT) }">
                             {{ month.quality_returnT | toFixed(0) }}
                         </td>
                     </tr>
                     <tr>
                         <td>Outside</td>
-                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_outsideT) }">
+                        <td v-for="month in monthly" :style="{ backgroundColor: qualityColor(month.quality_outsideT), color: qualityColorText(month.quality_outsideT) }">
                             {{ month.quality_outsideT | toFixed(0) }}
                         </td>
                     </tr>
@@ -451,6 +450,46 @@ global $settings, $session, $path;
                     // if score = 0 grey
                     if (score == 0) return '#ccc';
                     return `hsl(${hue}, 100%, 50%)`; // Convert hue value to HSL color
+                }
+            },
+            qualityColorText() {
+                return function(score) {
+                    if (score == 0) return '#000'; // Black text for grey background (#ccc has ~80% lightness)
+                    
+                    // Calculate perceived brightness of the HSL color
+                    const hue = (score / 100) * 120; // Same calculation as qualityColor
+                    const saturation = 100;
+                    const lightness = 50;
+                    
+                    // Convert HSL to RGB for luminance calculation
+                    const c = (1 - Math.abs(2 * lightness/100 - 1)) * saturation/100;
+                    const x = c * (1 - Math.abs((hue / 60) % 2 - 1));
+                    const m = lightness/100 - c/2;
+                    
+                    let r, g, b;
+                    if (hue >= 0 && hue < 60) {
+                        r = c; g = x; b = 0;
+                    } else if (hue >= 60 && hue < 120) {
+                        r = x; g = c; b = 0;
+                    } else if (hue >= 120 && hue < 180) {
+                        r = 0; g = c; b = x;
+                    } else if (hue >= 180 && hue < 240) {
+                        r = 0; g = x; b = c;
+                    } else if (hue >= 240 && hue < 300) {
+                        r = x; g = 0; b = c;
+                    } else {
+                        r = c; g = 0; b = x;
+                    }
+                    
+                    r = (r + m) * 255;
+                    g = (g + m) * 255;
+                    b = (b + m) * 255;
+                    
+                    // Calculate relative luminance using WCAG formula
+                    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+                    
+                    // Use white text for dark backgrounds (luminance < 0.5), black for light
+                    return luminance < 0.5 ? '#fff' : '#000';
                 }
             }
         },


### PR DESCRIPTION
Currently the data coverage table is a little hard to read: 
<img width="795" height="333" alt="Screenshot 2025-10-17 at 00 03 28" src="https://github.com/user-attachments/assets/757c9634-b00c-4280-beeb-57d72b6b3581" />

This change selects the text color to be black or white based on the background colour to make it more readable:
<img width="790" height="333" alt="Screenshot 2025-10-17 at 00 06 09" src="https://github.com/user-attachments/assets/f6fa3e86-6f21-4f75-bf0d-120efda4b2c4" />
