### PR TITLE
Minor bug with system photos

### DIFF
--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -121,9 +121,14 @@ defined('EMONCMS_EXEC') or die('Restricted access');
         max-height: 780px;
     }
 
+    /* Prevent flash of unstyled content before Vue initializes */
+    [v-cloak] {
+        display: none;
+    }
+
 </style>
 
-<div id="app" class="bg-light">
+<div id="app" class="bg-light" v-cloak>
     <div style=" background-color:#f0f0f0; padding-top:20px; padding-bottom:10px">
         <div class="container-fluid">
 


### PR DESCRIPTION
Add `v-cloak` directive to prevent flash of unstyled content before Vue initializes

How It Works

- The `v-cloak` directive stays on the element until Vue finishes compiling
- The CSS rule `[v-cloak] { display: none; }` hides the element while it has the `v-cloak` attribute
- Once Vue initializes and compiles the templates, it automatically removes the `v-cloak` attribute, making the content visible
- This ensures users never see uncompiled Vue templates or any flashing content during page load

Fixes #103