### PR TITLE
Fix for Sort by "Make & Model" column not working 

### DIFF
--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -911,6 +911,16 @@ defined('EMONCMS_EXEC') or die('Restricted access');
         }
         
         systems[z]['oversizing_factor'] = oversizing_factor;
+        
+        // Add computed hp_make_model field for sorting
+        systems[z]['hp_make_model'] = (system['hp_manufacturer'] || '') + ' ' + (system['hp_model'] || '');
+        
+        // Add computed training field for sorting (count of training badges)
+        let training_count = 0;
+        if (system['heatgeek'] == 1) training_count++;
+        if (system['ultimaterenewables'] == 1) training_count++;
+        if (system['heatingacademy'] == 1) training_count++;
+        systems[z]['training'] = training_count;
     }
 
     // if not 365 days column heading is COP


### PR DESCRIPTION
The content of the `Make & Model` are derived so were not in the systems table. not addedso it can be sorted by.

Also sorted sorting by Training and MID which did also not work, but it is all be it pointless.

Fixes #100