### PR TITLE
Link Make and Model of heat pump to database

### DIFF
--- a/www/Modules/heatpump/heatpump_schema.php
+++ b/www/Modules/heatpump/heatpump_schema.php
@@ -3,9 +3,9 @@
 // Model schema
 $schema['heatpump_model'] = array(
     'id' => array('type' => 'int(11)', 'Null' => false, 'Key' => 'PRI', 'Extra' => 'auto_increment'),
-    'manufacturer_id' => array('type' => 'int(11)'),
-    'name' => array('type' => 'varchar(128)'),
-    'capacity' => array('type' => 'varchar(10)', 'Null' => true, 'default' => null),
+    'manufacturer_id' => array('type' => 'int(11)', 'Index' => true),
+    'name' => array('type' => 'varchar(128)', 'Index' => true),
+    'capacity' => array('type' => 'varchar(10)', 'Null' => true, 'default' => null, 'Index' => true),
     'refrigerant' => array('type' => 'varchar(32)', 'Null' => true, 'default' => null),
     'type' => array('type' => 'varchar(32)', 'Null' => true, 'default' => null),
     'min_flowrate' => array('type' => 'float', 'Null' => true, 'default' => null),

--- a/www/Modules/manufacturer/manufacturer_schema.php
+++ b/www/Modules/manufacturer/manufacturer_schema.php
@@ -4,6 +4,6 @@
 // Heat pumps, hot water cylinders, etc.
 $schema['manufacturers'] = array(
     'id' => array('type' => 'int(11)', 'Null' => false, 'Key' => 'PRI', 'Extra' => 'auto_increment'),
-    'name' => array('type' => 'varchar(128)'),
+    'name' => array('type' => 'varchar(128)', 'Index' => true),
     'website' => array('type' => 'varchar(128)')
 );

--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -1462,7 +1462,14 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                 var val = system[key];
 
                 if (key=='hp_make_model') {
-                    var makeModel = system['hp_manufacturer'] + ' ' + system['hp_model'];
+                    // HTML-escape user-editable fields to prevent XSS
+                    var manufacturer = system['hp_manufacturer'] ? String(system['hp_manufacturer']).replace(/[&<>"']/g, function(m) {
+                        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m];
+                    }) : '';
+                    var model = system['hp_model'] ? String(system['hp_model']).replace(/[&<>"']/g, function(m) {
+                        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m];
+                    }) : '';
+                    var makeModel = manufacturer + ' ' + model;
                     // If we have a heatpump_url, make it a link
                     if (system['heatpump_url']) {
                         return '<a href="' + system['heatpump_url'] + '">' + makeModel + '</a>';

--- a/www/Modules/system/system_model.php
+++ b/www/Modules/system/system_model.php
@@ -73,7 +73,7 @@ class System
         
         // Add heatpump_url if both manufacturer and model are matched
         if ($row->heatpump_model_id) {
-            $row->heatpump_url = $path . 'heatpump/view?id=' . $row->heatpump_model_id;
+            $row->heatpump_url = $path . 'heatpump/view?id=' . (int)$row->heatpump_model_id;
         }
         
         // Remove private fields for public lists


### PR DESCRIPTION
Clicking on the Make and Model of a heat pump now directs users to the corresponding heat pump database page. Additionally, refactoring combines duplicate code for querying systems, improving maintainability.

Fixes #119