### PR TITLE
Allow 15 Moving Average COP

### DIFF
--- a/www/Modules/dashboard/myheatpump.php
+++ b/www/Modules/dashboard/myheatpump.php
@@ -228,6 +228,7 @@ $v=2;
                     <option value="0" selected>Disabled</option>
                     <option value="3">3 points</option>
                     <option value="5">5 points</option>
+                    <option value="15">15 points</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
With samsung heat pumps the pump will knock the compressor up and down every minute making a never noisy COP line,

By having a longer moving AVG it is easier to view