### PR TITLE
Add desktop-only ranking column with contiguous row numbering

### DIFF
--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -444,6 +444,7 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
                 <table v-else id="custom" class="table table-striped table-sm mt-3">
                     <tr>
+                        <th v-if="showContent" style="width:40px"></th>
                         <th v-if="mode!='public'" @click="sort('id', 'asc')" style="cursor:pointer">ID</th>
                         <th v-if="mode=='admin' || mode=='user'" @click="sort('name', 'asc')" style="cursor:pointer">User
                             <i :class="currentSortDir == 'asc' ? 'fa fa-arrow-up' : 'fa fa-arrow-down'" v-if="currentSortColumn=='name'"></i>
@@ -461,7 +462,8 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                         <th v-if="mode!='public'" :style="(showContent)?'width:120px':'width:20px'"></th>
 
                     </tr>
-                    <tr v-for="(system,index) in fSystems" v-if="mode!='public' || (mode=='public' && system.combined_data_length!=0)">
+                    <tr v-for="(system,index) in fSystems">
+                        <td v-if="showContent">{{ index + 1 }}</td>
                         <td v-if="mode!='public'">{{ system.id }}</td>
                         <td v-if="mode=='admin' || mode=='user'"><span style="color:#888">{{ system.username }}</span></td>
                         <td v-for="column in selected_columns" v-html="column_format(system,column)" v-bind:class="sinceClass(system,column)" style=""></td>
@@ -2037,6 +2039,10 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                 }
                 return show;
             },
+
+            filterPublicData(row) {
+                return this.mode != 'public' || row.combined_data_length != 0;
+            },
             
             system_count(systems) {
                 // Count flagged systems
@@ -2096,7 +2102,7 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                 
                 this.system_count(filtered_nodes_days);
             
-                this.fSystems = filtered_nodes_days.filter(this.filterMetering)
+                this.fSystems = filtered_nodes_days.filter(this.filterMetering).filter(this.filterPublicData)
 
                 if (this.chart_enable) {
                     draw_scatter();


### PR DESCRIPTION
Fixes #163

## Summary

This adds a ranking column to the system list tables that displays positional row numbers (1..N) on desktop.

## What changed
1. Added an empty-header, leftmost ranking column in the list table for desktop layouts.
2. Rendered row numbers from the displayed row position (index + 1).
3. Moved the public zero-data row condition into the filter pipeline so displayed numbering is contiguous.
4. Applied behavior consistently across public, user, and admin list modes.

## Behavior
- Desktop: ranking column is visible and re-numbers from 1 based on current displayed order.
- Mobile: ranking column is hidden.
- Sorting/filtering: numbers remain positional and contiguous.

## Validation performed
- Verified public, user, and admin views on desktop and mobile widths.
- Verified sorting changes row content while ranking remains 1..N top-to-bottom.
- Verified filtering re-sequences ranking without gaps.
- Confirmed no file diagnostics errors after the change.
