### PR TITLE
Use plain boundary values for filters and render boundary badge in formatter

### DIFF
--- a/www/Modules/system/system_list.php
+++ b/www/Modules/system/system_list.php
@@ -896,7 +896,7 @@ defined('EMONCMS_EXEC') or die('Restricted access');
             helper = "";
         }
         
-        systems[i].boundary = "<span class='H"+boundary_code+"' title='System boundary H"+boundary_code+"\n"+helper+"'>H"+boundary_code+"</span>";
+        systems[i].boundary = "H"+boundary_code;
         
         systems[i].boundary_code = boundary_code;
     }
@@ -1619,6 +1619,75 @@ defined('EMONCMS_EXEC') or die('Restricted access');
                         training += "<a href='https://heatingacademynorthampton.co.uk'><img class='heatingacademylogo' src='"+path+"theme/img/HA2.png' title='Heating Academy Hydronics'/></a>";
                     }
                     return training;
+                }
+
+                if (key=='boundary') {
+                    if (val==null || val==='') return '';
+
+                    let type = system['hp_type'];
+                    let metering = system['boundary_metering'] || {};
+                    let boundary_code = system['boundary_code'];
+                    let helper = "";
+
+                    // Compressor/fan status
+                    if (type == "Ground Source" || type == "Water Source") {
+                        helper = "- Compressor metered\n";
+                    } else if (type != "Air-to-Air") {
+                        helper = "- Compressor and fan metered\n";
+                    }
+
+                    // Hydraulic separation / secondary pumps
+                    if (metering.hydraulic_separation) {
+                        if (metering.secondary_pumps_metered === true) {
+                            helper += "- Hydraulic separation used and secondary pumps/fans metered\n";
+                        } else if (metering.secondary_pumps_metered === false) {
+                            helper += "- Hydraulic separation used but secondary pumps/fans not metered\n";
+                        }
+                    }
+
+                    // Primary pump
+                    if (metering.primary_pump_metered === true) {
+                        helper += "- Primary pump metered\n";
+                    } else if (metering.primary_pump_metered === false) {
+                        helper += "- Primary pump not metered\n";
+                    }
+
+                    // Immersion heater
+                    if (metering.immersion_heater_used === true) {
+                        if (metering.immersion_heater_metered === true) {
+                            helper += "- Immersion heater used and metered\n";
+                        } else if (metering.immersion_heater_metered === false) {
+                            helper += "- Immersion heater used but not metered\n";
+                        }
+                    } else if (metering.immersion_heater_used === false) {
+                        helper += "- Immersion heater not installed or used\n";
+                    }
+
+                    // Backup heater
+                    if (metering.backup_heater_used === true) {
+                        if (metering.backup_heater_metered === true) {
+                            helper += "- Backup heater used and metered\n";
+                        } else if (metering.backup_heater_metered === false) {
+                            helper += "- Backup heater used but not metered\n";
+                        }
+                    } else if (metering.backup_heater_used === false) {
+                        helper += "- Backup heater not installed or used\n";
+                    }
+
+                    // Brine pump
+                    if ((type == "Ground Source" || type == "Water Source")) {
+                        if (metering.brine_pump_metered === true) {
+                            helper += "- Brine pump used and metered\n";
+                        } else if (metering.brine_pump_metered === false) {
+                            helper += "- Brine pump used but not metered\n";
+                        }
+                    }
+
+                    if (type == "Air-to-Air") {
+                        helper = "";
+                    }
+
+                    return "<span class='H"+boundary_code+"' title='System boundary H"+boundary_code+"\n"+helper+"'>"+val+"</span>";
                 }
                 
                 if (key=='heatgeek') {


### PR DESCRIPTION
This fixes issue #162 where the boundary filter options displayed escaped HTML instead of clean boundary codes.

The root cause was that boundary values in the system list data were stored as rendered HTML spans.
Filter option generation reads raw field values, so those HTML strings were surfaced in the filter datalist.

Fixes  #162